### PR TITLE
Refactor partition by

### DIFF
--- a/lib/telluride_pipeline/telemetry_broadway_worker.ex
+++ b/lib/telluride_pipeline/telemetry_broadway_worker.ex
@@ -8,8 +8,6 @@ defmodule TelluridePipeline.TelemetryBroadwayWorker do
   alias TelluridePipeline.DataContainer.{BroadwayConfig, SensorTracker}
   alias TelluridePipeline.Data.SensorAggregate
 
-  @num_batchers 3
-
   ################################################################################
   # Client interface
   ################################################################################
@@ -36,14 +34,6 @@ defmodule TelluridePipeline.TelemetryBroadwayWorker do
       |> Message.put_batch_key(batch_key)
       |> Message.put_batcher(batch_partition)
     end
-
-    # handle_batch = fn _batcher, batch, _batch_info, _ ->
-      # batch
-      # |> IO.inspect(label: "batch: ")
-      # |> Enum.into([], fn %Message{} = msg ->
-        # msg.data
-      # end)
-    # end
 
     origin_pid = self()
 

--- a/lib/telluride_pipeline/telemetry_metrics.ex
+++ b/lib/telluride_pipeline/telemetry_metrics.ex
@@ -121,6 +121,9 @@ defmodule TelluridePipeline.TelemetryMetrics do
 
     %BatchInfo{} = info = metadata[:batch_info]
     # IO.inspect(info, label: "\nBatchInfo:\t")
+
+    ## batcher_processor "partition" is the number assigned to
+    ## the batch_key
     revised_partition =
       Map.get(info, :batch_key)
       |> String.split("_")
@@ -128,7 +131,6 @@ defmodule TelluridePipeline.TelemetryMetrics do
       |> String.to_integer()
 
     batcher = Map.get(info, :batcher)
-    # partition = Map.get(info, :partition)
     size = Map.get(info, :size)
 
     metric_map =

--- a/lib/telluride_pipeline/telemetry_metrics.ex
+++ b/lib/telluride_pipeline/telemetry_metrics.ex
@@ -121,16 +121,21 @@ defmodule TelluridePipeline.TelemetryMetrics do
 
     %BatchInfo{} = info = metadata[:batch_info]
     # IO.inspect(info, label: "\nBatchInfo:\t")
+    revised_partition =
+      Map.get(info, :batch_key)
+      |> String.split("_")
+      |> List.last()
+      |> String.to_integer()
 
     batcher = Map.get(info, :batcher)
-    partition = Map.get(info, :partition)
+    # partition = Map.get(info, :partition)
     size = Map.get(info, :size)
 
     metric_map =
       %{
         node_type: "batcher_processor",
         name: batcher,
-        partition: partition,
+        partition: revised_partition,
         call_count: 1,
         msg_count: size || 1,
         last_duration: measurements[:duration],


### PR DESCRIPTION
Now treating batch_key separately within each batcher and assigned based on different key than is used for the batcher.  This is necessary to fully saturate the batcher_processes.